### PR TITLE
Bug Fix (not showing correct unit of RAM capacity in the tag of Built PC)

### DIFF
--- a/src/main/java/mcvmcomputers/item/ItemPCCase.java
+++ b/src/main/java/mcvmcomputers/item/ItemPCCase.java
@@ -63,10 +63,18 @@ public class ItemPCCase extends OrderableItem{
 						tooltip.add(new TranslatableText("mcvmcomputers.pc_item_gpu").formatted(Formatting.GRAY));
 					if(stack.getTag().getInt("CPUDividedBy") > 0)
 						tooltip.add(new TranslatableText("mcvmcomputers.pc_item_cpu", stack.getTag().getInt("CPUDividedBy")).formatted(Formatting.GRAY));
-					if(stack.getTag().getInt("RAMSlot0") > 0)
-						tooltip.add(new TranslatableText("mcvmcomputers.pc_item_ramSlot0", stack.getTag().getInt("RAMSlot0")).formatted(Formatting.GRAY));
-					if(stack.getTag().getInt("RAMSlot1") > 0)
-						tooltip.add(new TranslatableText("mcvmcomputers.pc_item_ramSlot1", stack.getTag().getInt("RAMSlot1")).formatted(Formatting.GRAY));
+					if(stack.getTag().getInt("RAMSlot0") > 0) {
+						if((stack.getTag().getInt("RAMSlot0") / 1024) < 1) {
+							tooltip.add(new TranslatableText("mcvmcomputers.pc_item_ramSlot0Mb", stack.getTag().getInt("RAMSlot0")).formatted(Formatting.GRAY));
+						} else if((stack.getTag().getInt("RAMSlot0") / 1024) >= 1) {
+							tooltip.add(new TranslatableText("mcvmcomputers.pc_item_ramSlot0", (stack.getTag().getInt("RAMSlot0") / 1024)).formatted(Formatting.GRAY));
+					}}
+					if(stack.getTag().getInt("RAMSlot1") > 0) {
+						if((stack.getTag().getInt("RAMSlot1") / 1024) < 1) {
+							tooltip.add(new TranslatableText("mcvmcomputers.pc_item_ramSlot1Mb", stack.getTag().getInt("RAMSlot1")).formatted(Formatting.GRAY));
+						} else if((stack.getTag().getInt("RAMSlot1") / 1024) >= 1) {
+							tooltip.add(new TranslatableText("mcvmcomputers.pc_item_ramSlot1", (stack.getTag().getInt("RAMSlot1") / 1024)).formatted(Formatting.GRAY));
+					}}
 					if(!stack.getTag().getString("VHDName").isEmpty())
 						tooltip.add(new TranslatableText("mcvmcomputers.pc_item_hdd", stack.getTag().getString("VHDName")).formatted(Formatting.GRAY));
 					if(!stack.getTag().getString("ISOName").isEmpty())

--- a/src/main/java/mcvmcomputers/item/ItemPCCaseSidepanel.java
+++ b/src/main/java/mcvmcomputers/item/ItemPCCaseSidepanel.java
@@ -61,10 +61,18 @@ public class ItemPCCaseSidepanel extends OrderableItem{
 						tooltip.add(new TranslatableText("mcvmcomputers.pc_item_gpu").formatted(Formatting.GRAY));
 					if(stack.getTag().getInt("CPUDividedBy") > 0)
 						tooltip.add(new TranslatableText("mcvmcomputers.pc_item_cpu", stack.getTag().getInt("CPUDividedBy")).formatted(Formatting.GRAY));
-					if(stack.getTag().getInt("RAMSlot0") > 0)
-						tooltip.add(new TranslatableText("mcvmcomputers.pc_item_ramSlot0", stack.getTag().getInt("RAMSlot0")).formatted(Formatting.GRAY));
-					if(stack.getTag().getInt("RAMSlot1") > 0)
-						tooltip.add(new TranslatableText("mcvmcomputers.pc_item_ramSlot1", stack.getTag().getInt("RAMSlot1")).formatted(Formatting.GRAY));
+					if(stack.getTag().getInt("RAMSlot0") > 0) {
+						if((stack.getTag().getInt("RAMSlot0") / 1024) < 1) {
+							tooltip.add(new TranslatableText("mcvmcomputers.pc_item_ramSlot0Mb", stack.getTag().getInt("RAMSlot0")).formatted(Formatting.GRAY));
+						} else if((stack.getTag().getInt("RAMSlot0") / 1024) >= 1) {
+							tooltip.add(new TranslatableText("mcvmcomputers.pc_item_ramSlot0", (stack.getTag().getInt("RAMSlot0") / 1024)).formatted(Formatting.GRAY));
+					}}
+					if(stack.getTag().getInt("RAMSlot1") > 0) {
+						if((stack.getTag().getInt("RAMSlot1") / 1024) < 1) {
+							tooltip.add(new TranslatableText("mcvmcomputers.pc_item_ramSlot1Mb", stack.getTag().getInt("RAMSlot1")).formatted(Formatting.GRAY));
+						} else if((stack.getTag().getInt("RAMSlot1") / 1024) >= 1) {
+							tooltip.add(new TranslatableText("mcvmcomputers.pc_item_ramSlot1", (stack.getTag().getInt("RAMSlot1") / 1024)).formatted(Formatting.GRAY));
+					}}
 					if(!stack.getTag().getString("VHDName").isEmpty())
 						tooltip.add(new TranslatableText("mcvmcomputers.pc_item_hdd", stack.getTag().getString("VHDName")).formatted(Formatting.GRAY));
 					if(!stack.getTag().getString("ISOName").isEmpty())

--- a/src/main/resources/assets/mcvmcomputers/lang/de_de.json
+++ b/src/main/resources/assets/mcvmcomputers/lang/de_de.json
@@ -45,6 +45,8 @@
     "mcvmcomputers.open_with_right_click": "Paket mit Rechtsklick öffnen",
     "mcvmcomputers.pc_item_ramSlot0": "%s GB RAM in Steckplatz 1",
     "mcvmcomputers.pc_item_ramSlot1": "%s GB RAM in Steckplatz 2",
+    "mcvmcomputers.pc_item_ramSlot0Mb": "%s MB of RAM in slot 1",
+    "mcvmcomputers.pc_item_ramSlot1Mb": "%s MB of RAM in slot 2",
     "mcvmcomputers.pc_item_cpu": "1/%s Host-CPU eingebaut",
     "mcvmcomputers.pc_item_gpu": "GPU eingebaut",
     "mcvmcomputers.pc_item_hdd": "Festplatte eingesetzt: %s",

--- a/src/main/resources/assets/mcvmcomputers/lang/en_us.json
+++ b/src/main/resources/assets/mcvmcomputers/lang/en_us.json
@@ -45,6 +45,8 @@
     "mcvmcomputers.open_with_right_click": "Open package using right click",
     "mcvmcomputers.pc_item_ramSlot0": "%s GB of RAM in slot 1",
     "mcvmcomputers.pc_item_ramSlot1": "%s GB of RAM in slot 2",
+    "mcvmcomputers.pc_item_ramSlot0Mb": "%s MB of RAM in slot 1",
+    "mcvmcomputers.pc_item_ramSlot1Mb": "%s MB of RAM in slot 2",
     "mcvmcomputers.pc_item_cpu": "1/%s host CPU installed",
     "mcvmcomputers.pc_item_gpu": "GPU installed",
     "mcvmcomputers.pc_item_hdd": "Inserted hard drive: %s",

--- a/src/main/resources/assets/mcvmcomputers/lang/it_it.json
+++ b/src/main/resources/assets/mcvmcomputers/lang/it_it.json
@@ -45,6 +45,8 @@
     "mcvmcomputers.open_with_right_click": "Apri il pacco cliccando con il tasto destro",
     "mcvmcomputers.pc_item_ramSlot0": "%s GB di RAM nello slot 1",
     "mcvmcomputers.pc_item_ramSlot1": "%s GB di RAM nello slot 2",
+    "mcvmcomputers.pc_item_ramSlot0Mb": "%s MB of RAM in slot 1",
+    "mcvmcomputers.pc_item_ramSlot1Mb": "%s MB of RAM in slot 2",
     "mcvmcomputers.pc_item_cpu": "1/%s del Processore Host installato",
     "mcvmcomputers.pc_item_gpu": "Scheda Video installata",
     "mcvmcomputers.pc_item_hdd": "Disco rigido inserito: %s",


### PR DESCRIPTION
I don't think it's really a bug tho, just assuming it is.
- Fixed a bug that not showing correct unit of RAM capacity in tag of Built PC.
- Able to show the unit of MB/ GB according to RAM that user inserted in the Built PC in tag.