### PR TITLE
(Hopefully) Fix #161

### DIFF
--- a/src/main/java/mcvmcomputers/client/gui/GuiPCEditing.java
+++ b/src/main/java/mcvmcomputers/client/gui/GuiPCEditing.java
@@ -616,7 +616,7 @@ public class GuiPCEditing extends Screen{
 							}
 							edit.setOSTypeId(OSType);
 							edit.setMemorySize((long) Math.min(ClientMod.maxRam, (pc_case.getGigsOfRamInSlot0() + pc_case.getGigsOfRamInSlot1())));
-							edit.setCPUCount(Math.min(1, ClientMod.vb.getHost().getProcessorCount() / pc_case.getCpuDividedBy()));
+							edit.setCPUCount(Math.max(1, ClientMod.vb.getHost().getProcessorCount() / pc_case.getCpuDividedBy()));
 							edit.getGraphicsAdapter().setAccelerate2DVideoEnabled(true);
 							edit.getGraphicsAdapter().setAccelerate3DEnabled(true);
 							edit.getGraphicsAdapter().setVRAMSize((long)ClientMod.videoMem);


### PR DESCRIPTION
I was watching a video about the mod and they mentioned that the guest OS was limited to one core, so I decided to go through the code and try to find the misbehaving line of code. I believe I have succeeded in this. This pull request changes line 619 in GuiPCEditing.java to use Math.max instead of Math.min. I tested this by compiling the mod with my change and turning on the pc in-game and then checking VirtualBox to see if the core count was set correctly, which it was.

If you're curious [this](https://www.youtube.com/watch?v=uy3nfRB78os) was the video.